### PR TITLE
Add option to not log impressions

### DIFF
--- a/src/main/java/com/statsig/androidsdk/Statsig.kt
+++ b/src/main/java/com/statsig/androidsdk/Statsig.kt
@@ -93,11 +93,12 @@ object Statsig {
    * @throws IllegalStateException if the SDK has not been initialized
    */
   @JvmStatic
-  fun checkGate(gateName: String): Boolean {
+  @JvmOverloads
+  fun checkGate(gateName: String, logImpression: Boolean = true): Boolean {
     enforceInitialized("checkGate")
     var result = false
     errorBoundary.capture({
-      result = client.checkGate(gateName)
+      result = client.checkGate(gateName, logImpression)
     })
     return result
   }
@@ -110,11 +111,12 @@ object Statsig {
    * @throws IllegalStateException if the SDK has not been initialized
    */
   @JvmStatic
-  fun getConfig(configName: String): DynamicConfig {
+  @JvmOverloads
+  fun getConfig(configName: String, logImpression: Boolean = true): DynamicConfig {
     enforceInitialized("getConfig")
     var result: DynamicConfig? = null
     errorBoundary.capture({
-      result = client.getConfig(configName)
+      result = client.getConfig(configName, logImpression)
     })
     return result ?: DynamicConfig.getUninitialized(configName)
   }
@@ -129,11 +131,11 @@ object Statsig {
    */
   @JvmOverloads
   @JvmStatic
-  fun getExperiment(experimentName: String, keepDeviceValue: Boolean = false): DynamicConfig {
+  fun getExperiment(experimentName: String, keepDeviceValue: Boolean = false, logImpression: Boolean = true): DynamicConfig {
     enforceInitialized("getExperiment")
     var result: DynamicConfig? = null
     errorBoundary.capture({
-      result = client.getExperiment(experimentName, keepDeviceValue)
+      result = client.getExperiment(experimentName, keepDeviceValue, logImpression)
     })
     return result ?: DynamicConfig.getUninitialized(experimentName)
   }

--- a/src/main/java/com/statsig/androidsdk/StatsigClient.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigClient.kt
@@ -139,11 +139,13 @@ internal class StatsigClient() {
      * @return the value of the gate for the initialized user, or false if not found
      * @throws IllegalStateException if the SDK has not been initialized
      */
-    fun checkGate(gateName: String): Boolean {
+    fun checkGate(gateName: String, logImpression: Boolean = true): Boolean {
         enforceInitialized("checkGate")
         val res = store.checkGate(gateName)
-        statsigScope.launch {
-            logger.logGateExposure(gateName, res.value, res.ruleID, res.secondaryExposures, user, res.details)
+        if (logImpression) {
+            statsigScope.launch {
+                logger.logGateExposure(gateName, res.value, res.ruleID, res.secondaryExposures, user, res.details)
+            }
         }
         return res.value
     }
@@ -155,12 +157,14 @@ internal class StatsigClient() {
      * @return the Dynamic Config the initialized user
      * @throws IllegalStateException if the SDK has not been initialized
      */
-    fun getConfig(configName: String): DynamicConfig {
+    fun getConfig(configName: String, logImpression: Boolean = true): DynamicConfig {
         enforceInitialized("getConfig")
         val res = store.getConfig(configName)
-        statsigScope.launch {
-            logger.logConfigExposure(configName, res.getRuleID(), res.getSecondaryExposures(), user,
-                res.getEvaluationDetails())
+        if (logImpression) {
+            statsigScope.launch {
+                logger.logConfigExposure(configName, res.getRuleID(), res.getSecondaryExposures(), user,
+                    res.getEvaluationDetails())
+            }
         }
         return res
     }
@@ -173,12 +177,14 @@ internal class StatsigClient() {
      * @return the Dynamic Config backing the experiment
      * @throws IllegalStateException if the SDK has not been initialized
      */
-    fun getExperiment(experimentName: String, keepDeviceValue: Boolean = false): DynamicConfig {
+    fun getExperiment(experimentName: String, keepDeviceValue: Boolean = false, logImpression: Boolean = true): DynamicConfig {
         enforceInitialized("getExperiment")
         val res = store.getExperiment(experimentName, keepDeviceValue)
-        statsigScope.launch {
-            logger.logConfigExposure(experimentName, res.getRuleID(), res.getSecondaryExposures(), user,
-                res.getEvaluationDetails())
+        if (logImpression) {
+            statsigScope.launch {
+                logger.logConfigExposure(experimentName, res.getRuleID(), res.getSecondaryExposures(), user,
+                    res.getEvaluationDetails())
+            }
         }
         return res
     }

--- a/src/test/java/com/statsig/androidsdk/StatsigTest.kt
+++ b/src/test/java/com/statsig/androidsdk/StatsigTest.kt
@@ -79,10 +79,12 @@ class StatsigTest {
             Gson().toJson(mapOf("random_id" to "abcde"))
         )
         assertTrue(client.checkGate("always_on"))
+        assertTrue(client.checkGate("always_on", logImpression = false))
         assertFalse(client.checkGate("always_off"))
         assertFalse(client.checkGate("not_a_valid_gate_name"))
 
         val config = client.getConfig("test_config")
+        client.getConfig("test_config", logImpression = false)
         assertEquals("test", config.getString("string", "fallback"))
         assertEquals("test_config", config.getName())
         assertEquals(42, config.getInt("number", 0))
@@ -97,6 +99,7 @@ class StatsigTest {
         assertEquals("not_a_valid_config", invalidConfig.getName())
 
         val exp = client.getExperiment("exp")
+        client.getExperiment("exp", logImpression = false)
         assertEquals("exp", exp.getName())
         assertEquals(42, exp.getInt("number", 0))
 


### PR DESCRIPTION
Was working on something at Notion and realized it would be handy for us to be able to avoid logging impressions when checking experiments / gates in certain situations, so I decided to quickly just whip something up as a PR.

Let me know if this is okay!