### PR TITLE
[BUG FIX] Fix error when checking configs before network resolves

### DIFF
--- a/src/main/java/com/statsig/androidsdk/StatsigClient.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigClient.kt
@@ -83,7 +83,7 @@ internal class StatsigClient() {
     private suspend fun setupAsync(user: StatsigUser) {
         withContext(dispatcherProvider.io) {
             if (this@StatsigClient.options.loadCacheAsync) {
-                this@StatsigClient.store.syncLoadFromLocalStorage(user)
+                this@StatsigClient.store.syncLoadFromLocalStorage()
             }
             val initResponse = statsigNetwork.initialize(
                 this@StatsigClient.options.api,
@@ -140,7 +140,7 @@ internal class StatsigClient() {
             this@StatsigClient.statsigMetadata.overrideStableID(stableID)
         }
         if (!this@StatsigClient.options.loadCacheAsync) {
-            this@StatsigClient.store.syncLoadFromLocalStorage(normalizedUser)
+            this@StatsigClient.store.syncLoadFromLocalStorage()
         }
 
         this.initialized = true

--- a/src/main/java/com/statsig/androidsdk/StatsigClient.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigClient.kt
@@ -556,10 +556,6 @@ internal class StatsigClient() {
         StatsigUtil.saveStringToSharedPrefs(getSharedPrefs(), key, value)
     }
 
-    internal suspend fun removeFromSharedPrefs(key: String) {
-        StatsigUtil.removeFromSharedPrefs(getSharedPrefs(), key)
-    }
-
     private inner class StatsigActivityLifecycleListener : Application.ActivityLifecycleCallbacks {
         var currentActivity: Activity? = null
 

--- a/src/main/java/com/statsig/androidsdk/StatsigNetwork.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigNetwork.kt
@@ -62,6 +62,8 @@ internal interface StatsigNetwork {
     suspend fun apiPostLogs(api: String, sdkKey: String, bodyString: String)
 
     suspend fun apiRetryFailedLogs(api: String, sdkKey: String)
+
+    suspend fun addFailedLogRequest(body: String)
 }
 
 internal fun StatsigNetwork(): StatsigNetwork = StatsigNetworkImpl()
@@ -71,7 +73,7 @@ private class StatsigNetworkImpl : StatsigNetwork {
     private val gson =  GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create()
     private val dispatcherProvider = CoroutineDispatcherProvider()
     private var lastSyncTimeForUser: Long = 0
-    private lateinit var sharedPrefs: SharedPreferences
+    private var sharedPrefs: SharedPreferences? = null
 
     override suspend fun initialize(
         api: String,
@@ -145,7 +147,7 @@ private class StatsigNetworkImpl : StatsigNetwork {
         savedLogs.map { apiPostLogs(api, sdkKey, it.requestBody) }
     }
 
-    private suspend fun addFailedLogRequest(requestBody: String) {
+    override suspend fun addFailedLogRequest(requestBody: String) {
         withContext(dispatcherProvider.io) {
             val savedLogs = getSavedLogs() + StatsigOfflineRequest(System.currentTimeMillis(), requestBody)
             try {

--- a/src/main/java/com/statsig/androidsdk/StatsigOptions.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigOptions.kt
@@ -25,6 +25,7 @@ class StatsigOptions(
     @SerializedName("initTimeoutMs") var initTimeoutMs: Long = 3000L,
     @SerializedName("enableAutoValueUpdate") var enableAutoValueUpdate: Boolean = false,
     @SerializedName("overrideStableID") var overrideStableID: String? = null,
+    @SerializedName("loadCacheAsync") var loadCacheAsync: Boolean = false,
 ) {
 
     private var environment: MutableMap<String, String>? = null

--- a/src/main/java/com/statsig/androidsdk/StatsigUtil.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigUtil.kt
@@ -29,6 +29,17 @@ internal object StatsigUtil {
         }
     }
 
+    internal fun syncGetFromSharedPrefs(sharedPrefs: SharedPreferences?, key: String): String? {
+        if (sharedPrefs == null) {
+            return null
+        }
+        return try {
+            sharedPrefs.getString(key, null)
+        } catch (e: ClassCastException) {
+            null
+        }
+    }
+
     internal suspend fun saveStringToSharedPrefs(sharedPrefs: SharedPreferences?, key: String, value: String) {
         if (sharedPrefs == null) {
             return

--- a/src/main/java/com/statsig/androidsdk/StatsigUtil.kt
+++ b/src/main/java/com/statsig/androidsdk/StatsigUtil.kt
@@ -29,7 +29,10 @@ internal object StatsigUtil {
         }
     }
 
-    internal suspend fun saveStringToSharedPrefs(sharedPrefs: SharedPreferences, key: String, value: String) {
+    internal suspend fun saveStringToSharedPrefs(sharedPrefs: SharedPreferences?, key: String, value: String) {
+        if (sharedPrefs == null) {
+            return
+        }
         withContext(dispatcherProvider.io) {
             val editor = sharedPrefs.edit()
             editor.putString(key, value)
@@ -37,7 +40,10 @@ internal object StatsigUtil {
         }
     }
 
-    internal suspend fun removeFromSharedPrefs(sharedPrefs: SharedPreferences, key: String) {
+    internal suspend fun removeFromSharedPrefs(sharedPrefs: SharedPreferences?, key: String) {
+        if (sharedPrefs == null) {
+            return
+        }
         withContext(dispatcherProvider.io) {
             val editor = sharedPrefs.edit()
             editor.remove(key)
@@ -45,7 +51,10 @@ internal object StatsigUtil {
         }
     }
 
-    internal suspend fun getFromSharedPrefs(sharedPrefs: SharedPreferences, key: String): String? {
+    internal suspend fun getFromSharedPrefs(sharedPrefs: SharedPreferences?, key: String): String? {
+        if (sharedPrefs == null) {
+            return null
+        }
         return withContext(dispatcherProvider.io) {
             return@withContext try {
                 sharedPrefs.getString(key, null)

--- a/src/main/java/com/statsig/androidsdk/Store.kt
+++ b/src/main/java/com/statsig/androidsdk/Store.kt
@@ -51,7 +51,7 @@ internal class Store (private val statsigScope: CoroutineScope, private val shar
         reason = EvaluationReason.Uninitialized
     }
 
-    fun syncLoadFromLocalStorage(user: StatsigUser) {
+    fun syncLoadFromLocalStorage() {
         val cachedResponse = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
         val cachedDeviceValues = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
         val cachedLocalOverrides = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)

--- a/src/main/java/com/statsig/androidsdk/Store.kt
+++ b/src/main/java/com/statsig/androidsdk/Store.kt
@@ -62,10 +62,8 @@ internal class Store (private val statsigScope: CoroutineScope, private val shar
                 val localCache : Map<String, Cache> = gson.fromJson(cachedResponse, type)
                 cacheById = ConcurrentHashMap(localCache)
             } catch (_: Exception) {
-                statsigScope.launch {
-                    withContext(dispatcherProvider.io) {
-                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
-                    }
+                statsigScope.launch(dispatcherProvider.io) {
+                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
                 }
             }
         }
@@ -77,10 +75,8 @@ internal class Store (private val statsigScope: CoroutineScope, private val shar
                 val localSticky : Map<String, APIDynamicConfig> = gson.fromJson(cachedDeviceValues, type)
                 stickyDeviceExperiments = ConcurrentHashMap(localSticky)
             } catch (_: Exception) {
-                statsigScope.launch {
-                    withContext(dispatcherProvider.io) {
-                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
-                    }
+                statsigScope.launch(dispatcherProvider.io) {
+                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
                 }
             }
         }
@@ -90,10 +86,8 @@ internal class Store (private val statsigScope: CoroutineScope, private val shar
             try {
                 localOverrides = gson.fromJson(cachedLocalOverrides, StatsigOverrides::class.java)
             } catch (_: Exception) {
-                statsigScope.launch {
-                    withContext(dispatcherProvider.io) {
-                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
-                    }
+                statsigScope.launch(dispatcherProvider.io) {
+                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
                 }
             }
         }

--- a/src/main/java/com/statsig/androidsdk/Store.kt
+++ b/src/main/java/com/statsig/androidsdk/Store.kt
@@ -5,7 +5,9 @@ import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
@@ -30,7 +32,7 @@ private data class Cache(
     @SerializedName("evaluationTime") var evaluationTime: Long? = System.currentTimeMillis()
 )
 
-internal class Store (private val sharedPrefs: SharedPreferences, user: StatsigUser) {
+internal class Store (private val statsigScope: CoroutineScope, private val sharedPrefs: SharedPreferences, user: StatsigUser) {
     private val gson = Gson()
     private val dispatcherProvider = CoroutineDispatcherProvider()
     private var currentUserCacheKey: String
@@ -49,45 +51,54 @@ internal class Store (private val sharedPrefs: SharedPreferences, user: StatsigU
         reason = EvaluationReason.Uninitialized
     }
 
-    suspend fun loadFromLocalStorage(user: StatsigUser) {
-        withContext(dispatcherProvider.io) {
-            val cachedResponse = StatsigUtil.getFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
-            val cachedDeviceValues = StatsigUtil.getFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
-            val cachedLocalOverrides = StatsigUtil.getFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
+    fun syncLoadFromLocalStorage(user: StatsigUser) {
+        val cachedResponse = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
+        val cachedDeviceValues = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
+        val cachedLocalOverrides = StatsigUtil.syncGetFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
 
-            if (cachedResponse != null) {
-                val type = object : TypeToken<MutableMap<String, Cache>>() {}.type
-                try {
-                    val localCache : Map<String, Cache> = gson.fromJson(cachedResponse, type)
-                    cacheById = ConcurrentHashMap(localCache)
-                } catch (_: Exception) {
-                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
+        if (cachedResponse != null) {
+            val type = object : TypeToken<MutableMap<String, Cache>>() {}.type
+            try {
+                val localCache : Map<String, Cache> = gson.fromJson(cachedResponse, type)
+                cacheById = ConcurrentHashMap(localCache)
+            } catch (_: Exception) {
+                statsigScope.launch {
+                    withContext(dispatcherProvider.io) {
+                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY)
+                    }
                 }
             }
-
-            stickyDeviceExperiments = ConcurrentHashMap()
-            if (cachedDeviceValues != null) {
-                val type = object : TypeToken<MutableMap<String, APIDynamicConfig>>() {}.type
-                try {
-                    val localSticky : Map<String, APIDynamicConfig> = gson.fromJson(cachedDeviceValues, type)
-                    stickyDeviceExperiments = ConcurrentHashMap(localSticky)
-                } catch (_: Exception) {
-                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
-                }
-            }
-
-            localOverrides = StatsigOverrides.empty()
-            if (cachedLocalOverrides != null) {
-                try {
-                    localOverrides = gson.fromJson(cachedLocalOverrides, StatsigOverrides::class.java)
-                } catch (_: Exception) {
-                    StatsigUtil.removeFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
-                }
-            }
-            currentCache = loadCacheForCurrentUser()
-            attemptToMigrateDeprecatedStickyUserExperiments(user)
-            reason = EvaluationReason.Cache
         }
+
+        stickyDeviceExperiments = ConcurrentHashMap()
+        if (cachedDeviceValues != null) {
+            val type = object : TypeToken<MutableMap<String, APIDynamicConfig>>() {}.type
+            try {
+                val localSticky : Map<String, APIDynamicConfig> = gson.fromJson(cachedDeviceValues, type)
+                stickyDeviceExperiments = ConcurrentHashMap(localSticky)
+            } catch (_: Exception) {
+                statsigScope.launch {
+                    withContext(dispatcherProvider.io) {
+                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY)
+                    }
+                }
+            }
+        }
+
+        localOverrides = StatsigOverrides.empty()
+        if (cachedLocalOverrides != null) {
+            try {
+                localOverrides = gson.fromJson(cachedLocalOverrides, StatsigOverrides::class.java)
+            } catch (_: Exception) {
+                statsigScope.launch {
+                    withContext(dispatcherProvider.io) {
+                        StatsigUtil.removeFromSharedPrefs(sharedPrefs, LOCAL_OVERRIDES_KEY)
+                    }
+                }
+            }
+        }
+        currentCache = loadCacheForCurrentUser()
+        reason = EvaluationReason.Cache
     }
 
     fun loadAndResetForUser(user: StatsigUser) {
@@ -364,24 +375,5 @@ internal class Store (private val sharedPrefs: SharedPreferences, user: StatsigU
     suspend fun persistStickyValues() {
         StatsigUtil.saveStringToSharedPrefs(sharedPrefs, CACHE_BY_USER_KEY, gson.toJson(cacheById))
         StatsigUtil.saveStringToSharedPrefs(sharedPrefs, STICKY_DEVICE_EXPERIMENTS_KEY, gson.toJson(stickyDeviceExperiments))
-    }
-
-    private suspend fun attemptToMigrateDeprecatedStickyUserExperiments(user: StatsigUser) {
-        val oldStickyUserExperimentValues =
-            StatsigUtil.getFromSharedPrefs(sharedPrefs, DEPRECATED_STICKY_USER_EXPERIMENTS_KEY)
-                ?: return
-        StatsigUtil.removeFromSharedPrefs(sharedPrefs, DEPRECATED_STICKY_USER_EXPERIMENTS_KEY)
-
-        try {
-            val stickyUserExperiments = gson.fromJson(oldStickyUserExperimentValues, DeprecatedStickyUserExperiments::class.java)
-            if (stickyUserExperiments.userID != user.userID || currentCache.stickyUserExperiments.experiments.isNotEmpty()) {
-                return
-            }
-
-            currentCache.stickyUserExperiments = StickyUserExperiments(stickyUserExperiments.experiments)
-            cacheById[currentUserCacheKey] = currentCache
-        }
-        // no ops, since we've already removed the bad value
-        catch (_: Exception) {}
     }
 }

--- a/src/test/java/com/statsig/androidsdk/StatsigCacheTest.kt
+++ b/src/test/java/com/statsig/androidsdk/StatsigCacheTest.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 class StatsigCacheTest {
 
     private lateinit var app: Application
-    private var client: StatsigClient = StatsigClient()
+    private lateinit var client: StatsigClient
     private lateinit var testSharedPrefs: TestSharedPreferences
     private val gson = Gson()
 
@@ -59,6 +59,7 @@ class StatsigCacheTest {
 
         TestUtil.startStatsigAndDontWait(app, user, StatsigOptions())
         client = Statsig.client
+        assertTrue(client.isInitialized())
 
         assertTrue(client.checkGate("always_on"))
         runBlocking {

--- a/src/test/java/com/statsig/androidsdk/StatsigCacheTest.kt
+++ b/src/test/java/com/statsig/androidsdk/StatsigCacheTest.kt
@@ -95,5 +95,16 @@ class StatsigCacheTest {
         val config = client.getConfig("test_config")
         assertEquals("fallback", config.getString("string", "fallback"))
         assertEquals(EvaluationReason.Uninitialized, config.getEvaluationDetails().reason)
+
+        runBlocking {
+            Statsig.client.initialize(app, "client-test", user, StatsigOptions(loadCacheAsync = true))
+        }
+        assertTrue(client.checkGate("always_on"))
+
+        val netConfig = client.getConfig("test_config")
+        assertEquals("test", netConfig.getString("string", "fallback"))
+        assertEquals(EvaluationReason.Cache, netConfig.getEvaluationDetails().reason)
+
+        assertTrue(Statsig.client.isInitialized())
     }
 }

--- a/src/test/java/com/statsig/androidsdk/StoreTest.kt
+++ b/src/test/java/com/statsig/androidsdk/StoreTest.kt
@@ -106,7 +106,7 @@ class StoreTest {
     assertEquals(EvaluationReason.Uninitialized, exp.getEvaluationDetails().reason)
     assertEquals(EvaluationReason.Uninitialized, fakeConfig.getEvaluationDetails().reason)
 
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
 
     // save some value from "network" and check again
     store.save(getInitValue("v0", inExperiment = true, active = true), userJkw.getCacheKey())
@@ -121,7 +121,7 @@ class StoreTest {
     // re-initialize store, and check before any "network" value is saved
     Thread.sleep(1000) // wait 1 sec before reinitializing so that we can check the evaluation time in details has not advanced
     store = Store(TestCoroutineScope(), sharedPrefs, userJkw)
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
     exp = store.getExperiment(
       "exp",
       true
@@ -134,7 +134,7 @@ class StoreTest {
 
     // re-initialize and check the previously saved sticky value
     store = Store(TestCoroutineScope(), sharedPrefs, userJkw)
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
     store.save(getInitValue("v1", inExperiment = true, active = true), userJkw.getCacheKey())
     store.persistStickyValues()
 
@@ -278,7 +278,7 @@ class StoreTest {
   fun testStickyBehaviorAcrossSessions() = runBlocking {
     val sharedPrefs = TestSharedPreferences()
     var store = Store(TestCoroutineScope(), sharedPrefs, userJkw)
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
     val v0Values = getInitValue("v0", inExperiment = true, active = true)
     store.save(v0Values, userJkw.getCacheKey())
     store.persistStickyValues()
@@ -295,7 +295,7 @@ class StoreTest {
 
     // Reinitialize, same user ID, should keep sticky values
     store = Store(TestCoroutineScope(), sharedPrefs, userJkw)
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
     val configs = v0Values.configs as MutableMap<String, APIDynamicConfig>
 
     configs["exp!"] = newConfigUpdatingValue(configs["exp!"]!!, mapOf("key" to "v0_alt"))
@@ -315,7 +315,7 @@ class StoreTest {
     // Re-create store with a different user ID, update the values, user should still get sticky
     // value for device and only device
     store = Store(TestCoroutineScope(), sharedPrefs, userTore)
-    store.syncLoadFromLocalStorage(userTore)
+    store.syncLoadFromLocalStorage()
     store.save(getInitValue("v1", inExperiment = true, active = true), userTore.getCacheKey())
 
     config = store.getExperiment("config", true)
@@ -329,7 +329,7 @@ class StoreTest {
 
     // Re-create store with the original user ID, check that sticky values are persisted
     store = Store(TestCoroutineScope(), sharedPrefs, userJkw)
-    store.syncLoadFromLocalStorage(userJkw)
+    store.syncLoadFromLocalStorage()
     store.save(getInitValue("v2", inExperiment = true, active = true), userJkw.getCacheKey())
 
     config = store.getExperiment("config", true)

--- a/src/test/java/com/statsig/androidsdk/TestUtil.kt
+++ b/src/test/java/com/statsig/androidsdk/TestUtil.kt
@@ -224,13 +224,6 @@ class TestUtil {
                 StatsigOptions::class.java
             )
             setupMethod.isAccessible = true
-            val parameters = arrayOfNulls<Any>(4)
-            parameters[0] = app
-            parameters[1] = "client-test"
-            parameters[2] = user
-            parameters[3] = options
-            println(setupMethod.parameterCount)
-            println(parameters.size)
             setupMethod.invoke(Statsig.client, app, "client-test", user, options)
         }
 

--- a/src/test/java/com/statsig/androidsdk/TestUtil.kt
+++ b/src/test/java/com/statsig/androidsdk/TestUtil.kt
@@ -305,6 +305,10 @@ class TestUtil {
             }
 
             coEvery {
+                statsigNetwork.addFailedLogRequest(any())
+            } answers {}
+
+            coEvery {
                 statsigNetwork.apiPostLogs(any(), any(), any())
             } answers {}
 

--- a/src/test/java/com/statsig/androidsdk/TestUtil.kt
+++ b/src/test/java/com/statsig/androidsdk/TestUtil.kt
@@ -213,7 +213,7 @@ class TestUtil {
         }
 
         @JvmName("startStatsigAndDontWait")
-        internal fun startStatsigAndDontWait(app: Application, user: StatsigUser = StatsigUser("jkw"), options: StatsigOptions = StatsigOptions()) {
+        internal fun startStatsigAndDontWait(app: Application, user: StatsigUser, options: StatsigOptions) {
             Statsig.client = StatsigClient()
 
             val setupMethod = Statsig.client.javaClass.getDeclaredMethod(

--- a/src/test/java/com/statsig/androidsdk/TestUtil.kt
+++ b/src/test/java/com/statsig/androidsdk/TestUtil.kt
@@ -213,12 +213,25 @@ class TestUtil {
         }
 
         @JvmName("startStatsigAndDontWait")
-        internal fun startStatsigAndDontWait(app: Application, user: StatsigUser = StatsigUser("jkw"), options: StatsigOptions = StatsigOptions(), network: StatsigNetwork? = null) = runBlocking {
+        internal fun startStatsigAndDontWait(app: Application, user: StatsigUser = StatsigUser("jkw"), options: StatsigOptions = StatsigOptions()) {
             Statsig.client = StatsigClient()
-            if (network != null) {
-                Statsig.client.statsigNetwork = network
-            }
-            Statsig.initialize(app, "client-apikey", user, options)
+
+            val setupMethod = Statsig.client.javaClass.getDeclaredMethod(
+                "setup",
+                Application::class.java,
+                String::class.java,
+                StatsigUser::class.java,
+                StatsigOptions::class.java
+            )
+            setupMethod.isAccessible = true
+            val parameters = arrayOfNulls<Any>(4)
+            parameters[0] = app
+            parameters[1] = "client-test"
+            parameters[2] = user
+            parameters[3] = options
+            println(setupMethod.parameterCount)
+            println(parameters.size)
+            setupMethod.invoke(Statsig.client, app, "client-test", user, options)
         }
 
         fun getMockApp(): Application {


### PR DESCRIPTION
Context: https://github.com/statsig-io/android-sdk/issues/8


Test Plan:
- Reproduced the error via the `StatsigCacheTest` when updating the mocks
- Removed the lateinit in the network class to prevent the error
- Updated initialization path with synchronous local storage which was incorrectly moved (and the test had mocked improperly)