### PR TITLE
Use logcat instead of println

### DIFF
--- a/src/main/java/com/statsig/androidsdk/ErrorBoundary.kt
+++ b/src/main/java/com/statsig/androidsdk/ErrorBoundary.kt
@@ -1,5 +1,6 @@
 package com.statsig.androidsdk
 
+import android.util.Log
 import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineExceptionHandler
 import java.io.DataOutputStream
@@ -22,8 +23,6 @@ internal class ErrorBoundary() {
   }
 
   private fun handleException(exception: Throwable) {
-    println("[Statsig]: An unexpected exception occurred.")
-    println(exception)
     this.logException(exception)
   }
 
@@ -61,6 +60,8 @@ internal class ErrorBoundary() {
   }
 
   internal fun logException(exception: Throwable) {
+    Log.d("Statsig", "An unexpected exception occurred", exception)
+
     try {
       if (apiKey == null) {
         return


### PR DESCRIPTION
Noticed that print-lines were added `4.9.5` to print out logs.
Please do let me know if you would rather see this reported as `Log.e`.