### PR TITLE
Dispatching the Gson operation to worker thread

### DIFF
--- a/src/main/java/com/statsig/androidsdk/Store.kt
+++ b/src/main/java/com/statsig/androidsdk/Store.kt
@@ -6,7 +6,6 @@ import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
 private const val CACHE_BY_USER_KEY: String = "Statsig.CACHE_BY_USER"


### PR DESCRIPTION
Currently, the library initializes on the main thread, and a Gson operation performed there can lead to ANRs for consumers. This draft PR proposes moving the deserialization step to a worker thread to prevent those ANRs.