### PR TITLE
Remove legacy Statsig identity references

### DIFF
--- a/src/main/java/com/statsig/androidsdk/Store.kt
+++ b/src/main/java/com/statsig/androidsdk/Store.kt
@@ -833,7 +833,7 @@ internal class Store(
         }
     }
 
-    // Sticky Logic: https://gist.github.com/daniel-statsig/3d8dfc9bdee531cffc96901c1a06a402
+    // Sticky logic
     private fun getPossiblyStickyValue(
         snapshot: CacheSnapshot,
         name: String,


### PR DESCRIPTION
# Summary

- Remove current source references to legacy personal Statsig identities.
- Preserve runtime behavior while using organization-neutral comments, metadata, and fixtures.

# Test Plan

- Verified the changed manifests and fixtures still parse successfully.
- Reviewed the diff for unintended behavior changes.